### PR TITLE
Fix tar command returning an error

### DIFF
--- a/scripts/build_rootfs.sh
+++ b/scripts/build_rootfs.sh
@@ -65,9 +65,9 @@ unpack() {
 pack() {
 	echo Pack rootfs
 	if test -n "$metadata"; then
-		(cd $dir && tar -cz *) > $dst_file
+		(cd $dir && tar -cz * || true) > $dst_file
 	else
-		(cd $dir/rootfs && tar -cz *) > $dst_file
+		(cd $dir/rootfs && tar -cz * || true) > $dst_file
 	fi
 }
 


### PR DESCRIPTION
Prevents the full script to return an error because of tar unable to read symlinks outside of the fakeroot.