### PR TITLE
Add reboot event to allow rebooting of the container

### DIFF
--- a/patches/procd-openwrt-18.06/0003-docker-fix-problem-stopping-container.patch
+++ b/patches/procd-openwrt-18.06/0003-docker-fix-problem-stopping-container.patch
@@ -11,7 +11,7 @@ diff --git a/state.c b/state.c
 index ccf4104..bd59d7e 100644
 --- a/state.c
 +++ b/state.c
-@@ -157,18 +157,7 @@ static void state_enter(void)
+@@ -157,18 +157,8 @@ static void state_enter(void)
  		else
  			LOG("- reboot -\n");
  
@@ -27,6 +27,7 @@ index ccf4104..bd59d7e 100644
 -		}
 -		while (1)
 -			sleep(1);
++		reboot(reboot_event);
 +		exit(0);
  #else
  		exit(0);


### PR DESCRIPTION
This PR is to address a bug where the OpenWRT container would shut down completely when a restart would be attempted.
The bug report can be found here: https://github.com/mikma/lxd-openwrt/issues/14